### PR TITLE
Fix build action environment variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           github.ref == 'refs/heads/main' && vars.PUBLISH_LATEST_ON_MAIN != ''
           || github.event_name == 'workflow_dispatch' && inputs.publishDev
         }}
-      LOGIN_SERVER: ${{ secrets.LOGIN_SERVER }}
+      LOGIN_SERVER: snomedcta100.azurecr.io
       IMAGE: snomedct-competition
       SHA_TAG: ${{ matrix.proc }}-${{ github.sha }}
       LATEST_TAG: ${{ matrix.proc }}-latest


### PR DESCRIPTION
For reasons, loading `secrets` in the `environment` section of the build action leads to null values being populated. This is probably fixable in other ways, but the login server URL is not a secret since we use it to host the image, so this is probably the easiest / most straightforward fix. 