### PR TITLE
Update environment-cpu.yml

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -30,7 +30,7 @@ dependencies:
   - scikit-learn=1.4.0
   - scipy=1.10.1
   - sentencepiece=0.1.99
-  - sentence-transformers=2.3.1
+  - sentence-transformers=2.5.1
   - spacy=3.6.1
   - statsmodels=0.14.1
   - tensorflow-base=2.14.0=cpu*


### PR DESCRIPTION
AttributeError: Can't get attribute 'pairwise_angle_sim' on <module 'sentence_transformers.util' from '/opt/conda/lib/python3.10/site-packages/sentence_transformers/util.py'>

Error when using linker, using same process as benchmark