### PR TITLE
Update environment-gpu.yml

### DIFF
--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -33,7 +33,7 @@ dependencies:
   - scikit-learn=1.4.0
   - scipy=1.10.1
   - sentencepiece=0.1.99
-  - sentence-transformers=2.3.1
+  - sentence-transformers=2.5.1
   - spacy=3.6.1
   - statsmodels=0.14.1
   - tensorflow-base=2.14.0=cuda118*


### PR DESCRIPTION
AttributeError: Can't get attribute 'pairwise_angle_sim' on <module 'sentence_transformers.util' from '/opt/conda/lib/python3.10/site-packages/sentence_transformers/util.py'>

Error when using linker, using same process as benchmark